### PR TITLE
Cast value when assigning and support Rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This may cause a human error in some use cases.
 With PunctualDateSelect, you can hold invalid date as they are specified by an user and show the invalid error message.
 Therefore users can notice the mistakes they've made.
 
-This gem is for Rails 4 currently.
-
 ## Key concept
 
 Using PunctualDateSelect, your date column value won't have Date object while it is non-existing date.
@@ -19,6 +17,13 @@ You can use to_date or to_s in your code to get the valid date information.
 If the specified date from punctual_date_select fields is collect, it will be casted into Date object before validation.
 
 Note that you need to run validation before you save it not to send those parameters holding invalid date data to DB.
+
+## Supported Versions
+
+* Ruby
+  * 2.0 or higher
+* Rails
+  * 4.2, 5.0, 5.1
 
 ## Installation
 

--- a/lib/punctual_date_select/model.rb
+++ b/lib/punctual_date_select/model.rb
@@ -52,13 +52,12 @@ module PunctualDateSelect
           end
 
           define_method "#{column_name}=" do |value|
-            self[column_name] = (value.kind_of?(Hash) && !value.values.any?{|t| !t.blank?}) ? nil : value
             if value.kind_of?(Hash) && !value.kind_of?(PunctualDateSelect::DateHash)
               class << value
                 include PunctualDateSelect::DateHash
               end
             end
-            self[column_name]
+            self[column_name] = (value.kind_of?(Hash) && !value.values.any?{|t| !t.blank?}) ? nil : value
           end
 
           private cast_method, validation_method

--- a/lib/punctual_date_select/model.rb
+++ b/lib/punctual_date_select/model.rb
@@ -57,7 +57,7 @@ module PunctualDateSelect
                 include PunctualDateSelect::DateHash
               end
             end
-            self[column_name] = (value.kind_of?(Hash) && !value.values.any?{|t| !t.blank?}) ? nil : value
+            self[column_name] = (value.kind_of?(Hash) && value.values.any?{|t| t.blank?}) ? nil : value
           end
 
           private cast_method, validation_method

--- a/lib/punctual_date_select/model.rb
+++ b/lib/punctual_date_select/model.rb
@@ -44,7 +44,7 @@ module PunctualDateSelect
           end
 
           define_method "#{column_name}=" do |value|
-            if value.kind_of?(Hash) && !value.kind_of?(PunctualDateSelect::DateHash)
+            if value.kind_of?(Hash) && !value.kind_of?(PunctualDateSelect::DateHash) && (value.keys & %i[year month day]).any?
               class << value
                 include PunctualDateSelect::DateHash
               end

--- a/lib/punctual_date_select/model.rb
+++ b/lib/punctual_date_select/model.rb
@@ -36,14 +36,6 @@ module PunctualDateSelect
     module ClassMethods
       def punctual_date_column(*args)
         args.each do |column_name|
-          cast_method = :"cast_#{column_name}_if_possible"
-          before_validation cast_method
-
-          define_method cast_method do
-            casted_date = send(column_name).try(:to_date)
-            send("#{column_name}=", casted_date) if casted_date
-          end
-
           validation_method = :"validate_#{column_name}_is_casted"
           validate validation_method
 
@@ -60,7 +52,7 @@ module PunctualDateSelect
             self[column_name] = (value.kind_of?(Hash) && value.values.any?{|t| t.blank?}) ? nil : value
           end
 
-          private cast_method, validation_method
+          private validation_method
         end
       end
     end

--- a/lib/punctual_date_select/model.rb
+++ b/lib/punctual_date_select/model.rb
@@ -61,5 +61,23 @@ module PunctualDateSelect
       base.extend(ClassMethods)
     end
   end
+
+  module Type
+    cast_method = defined?(ActiveModel::Type) ? :value_from_multiparameter_assignment : :cast_value
+    define_method cast_method do |value|
+      if value.kind_of?(PunctualDateSelect::DateHash)
+        value.try(:to_date) || value
+      else
+        super(value)
+      end
+    end
+  end
 end
 ActiveRecord::Base.send(:include, PunctualDateSelect::Model)
+if defined?(ActiveModel::Type)
+  ActiveModel::Type::Date.send(:prepend, PunctualDateSelect::Type)
+  ActiveModel::Type::DateTime.send(:prepend, PunctualDateSelect::Type)
+else
+  ActiveRecord::Type::Date.send(:prepend, PunctualDateSelect::Type)
+  ActiveRecord::Type::DateTime.send(:prepend, PunctualDateSelect::Type)
+end


### PR DESCRIPTION
Basically, ActiveRecord attributes' values are casted when assigning.
This change follows that behavior.
And supports both Rails5 and Rails4.